### PR TITLE
[YUPTOO-16] Remove --deploy flag from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY Pipfile Pipfile.lock main.py ${APP_ROOT}/src/
 COPY yuptoo ${APP_ROOT}/src/yuptoo/
 RUN pip install --upgrade pip && \
     pip install pipenv && \
-    pipenv install --system --deploy --ignore-pipfile
+    pipenv install --system --ignore-pipfile


### PR DESCRIPTION
Not sure why we are getting error - `ERROR:: See also: {} --deploy flag` while building image in pr_check job. 
I viewed other projects and as other project like [inventory](https://github.com/RedHatInsights/insights-host-inventory/blob/master/Dockerfile#L24) is not using --deploy flag removing it from here. 