### PR TITLE
Fixes #YUPTOO-35 - Optimized Yuptoo code to use less memory

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ import json
 from yuptoo.lib.config import KAFKA_AUTO_COMMIT, ANNOUNCE_TOPIC, METRICS_PORT
 from yuptoo.lib.logger import initialize_logging, threadctx
 import logging
-from yuptoo.lib.exceptions import QPCKafkaMsgException
-from yuptoo.lib.metrics import kafka_failures, report_processing_exceptions
+from yuptoo.lib.exceptions import QPCKafkaMsgException, FailExtractException
+from yuptoo.lib.metrics import kafka_failures, report_processing_exceptions, extract_report_slices_failures
 from yuptoo.validators.qpc_message_validator import validate_qpc_message
 from yuptoo.processor.report_processor import process_report
 from yuptoo.lib import consume, produce
@@ -53,7 +53,12 @@ while True:
         kafka_failures.labels(
             org_id=msg['org_id']
         ).inc()
-        LOG.error(f"Error processing records.  Message: {msg}, Error: {message_error}")
+        LOG.error(f"Error processing Kafka message.  Message: {msg}, Error: {message_error}")
+    except FailExtractException as err:
+        extract_report_slices_failures.labels(
+                    org_id=request_obj['org_id']
+                ).inc()
+        LOG.error(f"Error Extracting report.  Message: {msg}, Error: {err}")
     except Exception as err:
         report_processing_exceptions.labels(
             org_id=msg['org_id']

--- a/tests/processor/test_report_processor.py
+++ b/tests/processor/test_report_processor.py
@@ -19,7 +19,8 @@ def test_process_report_without_facts():
         }
     report_json = {
         'report_slice_id': str(uuid1),
-        'hosts': [{str(uuid1): {'key': 'value'}}]}
+        'hosts': [{'key': 'value', 'fqdn': "test.example.com"}]
+    }
     report_files = {
         'metadata.json': metadata_json,
         '%s.json' % str(uuid1): report_json

--- a/tests/processor/test_report_processor.py
+++ b/tests/processor/test_report_processor.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 from datetime import datetime
-from yuptoo.processor.report_processor import extract_report_slices, process_report
+from yuptoo.processor.report_processor import process_report
 from yuptoo.lib.exceptions import QPCReportException
 from tests.utils import create_tar_buffer
 
@@ -82,28 +82,3 @@ def test_process_report():
             with patch('yuptoo.processor.report_processor.HOSTS_TRANSFORMATION_ENABLED', 0):
                 process_report(consumed_message, producer, request_object)
     mock.assert_called_once
-
-
-def test_extract_report_slices():
-    uuid1 = uuid.uuid4()
-    metadata_json = {
-            'report_id': 1,
-            'host_inventory_api_version': '1.0.0',
-            'source': 'qpc',
-            'source_metadata': {'foo': 'bar'},
-            'report_slices': {str(uuid1): {'number_hosts': 1}}
-        }
-    report_json = {
-        'report_slice_id': str(uuid1),
-        'hosts': {str(uuid1): {'key': 'value'}}}
-    report_files = {
-        'metadata.json': metadata_json,
-        '%s.json' % str(uuid1): report_json
-    }
-    request_obj = {}
-    request_obj['account'] = 123
-    request_obj['org_id'] = 123
-    request_obj['request_id'] = 456
-    buffer_content = create_tar_buffer(report_files)
-    result = extract_report_slices(buffer_content, request_obj)
-    assert [{'hosts': {str(uuid1): {'key': 'value'}}, 'report_slice_id': str(uuid1)}] == result

--- a/yuptoo/processor/report_processor.py
+++ b/yuptoo/processor/report_processor.py
@@ -22,6 +22,13 @@ FAILURE_CONFIRM_STATUS = 'failure'
 
 
 def process_report_slice(report_slice, request_obj):
+    """
+    Run all the modifiers on report slice and send modified host
+    to host-inventory
+    Args:
+        report_slice (dict): Contains hosts array
+        request_obj (dict): Object containing metadata of incoming request/report
+    """
     status = FAILURE_CONFIRM_STATUS
     LOG.info(f"Processing hosts in slice with id - {report_slice.get('report_slice_id')}")
     hosts = report_slice.get('hosts', [])
@@ -112,7 +119,7 @@ def send_message(kafka_topic, msg):
 
 
 def process_report(consumed_message, p, request_obj):
-    """Extract and Process Insights report"""
+    """Extract, Validate and Process report"""
     global producer
     producer = p
     request_obj.update({
@@ -176,7 +183,7 @@ def process_report(consumed_message, p, request_obj):
                                 LOG.warning(mismatch_message)
                                 continue
 
-                            # Here performance can be improved by using Async thread
+                            # FIXME - performance can be improved by using Async thread
                             process_report_slice(report_slice_json, request_obj)
                 log_report_summary(request_obj)
             except ValueError as error:


### PR DESCRIPTION
Instead of loading all uuid.json files into single array, with this PR uuid.json files should be processed one by one. Hoping python garbage collector should be freeing up memory in each iteration of for loop - [here](https://github.com/patilsuraj767/yuptoo/blob/use-less-memory/yuptoo/processor/report_processor.py#L141).