### PR TITLE
Refs #YUPTOO-47 - Fix host counter issue

### DIFF
--- a/tests/processor/test_report_processor.py
+++ b/tests/processor/test_report_processor.py
@@ -43,8 +43,9 @@ def test_process_report_without_facts():
         with patch('yuptoo.processor.report_processor.HOSTS_TRANSFORMATION_ENABLED', 0):
             with patch('yuptoo.processor.report_processor.has_canonical_facts', return_value=0):
                 with patch('yuptoo.processor.report_processor.send_message', return_value=0):
-                    with pytest.raises(QPCReportException):
-                        process_report(consumed_message, request_object)
+                    with patch('yuptoo.lib.produce.producer'):
+                        with pytest.raises(QPCReportException):
+                            process_report(consumed_message, request_object)
 
 
 def test_process_report():
@@ -81,5 +82,6 @@ def test_process_report():
         with patch('yuptoo.processor.report_processor.download_report', return_value=buffer_content):
             with patch('yuptoo.processor.report_processor.HOSTS_TRANSFORMATION_ENABLED', 0):
                 with patch('yuptoo.processor.report_processor.send_message', return_value=0):
-                    process_report(consumed_message, request_object)
+                    with patch('yuptoo.lib.produce.producer'):
+                        process_report(consumed_message, request_object)
     mock.assert_called_once

--- a/yuptoo/lib/produce.py
+++ b/yuptoo/lib/produce.py
@@ -1,5 +1,8 @@
 from confluent_kafka import Producer, KafkaException
-from yuptoo.lib.config import INSIGHTS_KAFKA_ADDRESS, KAFKA_PRODUCER_OVERRIDE_MAX_REQUEST_SIZE, kafka_auth_config
+from yuptoo.lib.config import (INSIGHTS_KAFKA_ADDRESS, KAFKA_PRODUCER_OVERRIDE_MAX_REQUEST_SIZE,
+                               kafka_auth_config, UPLOAD_TOPIC)
+from functools import partial
+from yuptoo.lib.metrics import host_uploaded, host_upload_failures
 import logging
 import json
 
@@ -18,22 +21,30 @@ def init_producer():
     return producer
 
 
-def send_message(kafka_topic, msg):
+def send_message(kafka_topic, msg, request_obj=None):
 
-    msg_sent = False
-
-    def delivery_report(err, msg=None):
+    def delivery_report(err, msg=None, is_msg_for_hbi=False):
+        nonlocal request_obj
         if err is not None:
             LOG.error(f"Message delivery for topic {msg.topic()} failed: {err}")
+            if is_msg_for_hbi:
+                host_upload_failures.labels(
+                        org_id=request_obj['org_id']
+                    ).inc()
         else:
-            nonlocal msg_sent
-            msg_sent = True
+            if is_msg_for_hbi:
+                request_obj['host_inventory_upload_count'] += 1
+                host_uploaded.labels(
+                        org_id=request_obj['org_id']
+                    ).inc()
             LOG.debug(f"Message delivered to {msg.topic()} [{msg.partition()}]")
 
     try:
         bytes = json.dumps(msg, ensure_ascii=False).encode("utf-8")
-        producer.produce(kafka_topic, bytes, callback=delivery_report)
+        if kafka_topic == UPLOAD_TOPIC:
+            producer.produce(kafka_topic, bytes, callback=partial(delivery_report, is_msg_for_hbi=True))
+        else:
+            producer.produce(kafka_topic, bytes, callback=delivery_report)
         producer.poll(1)
-        return msg_sent
     except KafkaException:
         LOG.error(f"Failed to produce message to [{kafka_topic}] topic.")


### PR DESCRIPTION
 [producer.produce()](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/lib/produce.py#L35) is an async function so it might happen that [delivery_report](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/lib/produce.py#L25) executes after printing [log_report_summary](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/processor/report_processor.py#L182) and this will result into incorrect host count as we increment the [host_inventory_upload_count](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/processor/report_processor.py#L104) based on [msg_sent](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/lib/produce.py#L30) variable which is set under [delivery_report](https://github.com/RedHatInsights/yuptoo/blob/f19547066ec741bd7b70868c69f83336a616f1d9/yuptoo/lib/produce.py#L25) 