### PR TITLE
Refs #YUPTOO-38 - remove org_id from all the metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,19 +61,13 @@ while True:
     except json.decoder.JSONDecodeError:
         LOG.error(f"Unable to decode kafka message: {msg.value()}")
     except QPCKafkaMsgException as message_error:
-        kafka_failures.labels(
-            org_id=msg['org_id']
-        ).inc()
+        kafka_failures.inc()
         LOG.error(f"Error processing Kafka message.  Message: {msg}, Error: {message_error}")
     except FailExtractException as err:
-        extract_report_slices_failures.labels(
-                    org_id=request_obj['org_id']
-                ).inc()
+        extract_report_slices_failures.inc()
         LOG.error(f"Error Extracting report.  Message: {msg}, Error: {err}")
     except Exception as err:
-        report_processing_exceptions.labels(
-            org_id=msg['org_id']
-        ).inc()
+        report_processing_exceptions.inc()
         LOG.error(f"An error occurred during message processing: {repr(err)}")
     finally:
         if not KAFKA_AUTO_COMMIT:

--- a/yuptoo/lib/metrics.py
+++ b/yuptoo/lib/metrics.py
@@ -7,42 +7,36 @@ archive_downloaded_success = Counter(
 
 archive_failed_to_download = Counter(
     "yuptoo_archive_failed_to_download",
-    "Total number of archives that failed to download",
-    ["org_id"]
+    "Total number of archives that failed to download"
 )
 
 extract_report_slices_failures = Counter(
     "yuptoo_extract_report_slices_failures",
-    "Total number of failures while extracting report slice",
-    ["org_id"]
+    "Total number of failures while extracting report slice"
 )
 
 report_processing_exceptions = Counter(
     "yuptoo_report_processing_exceptions",
-    "Total number of exceptions while processing report",
-    ["org_id"]
+    "Total number of exceptions while processing report"
 )
 
 host_uploaded = Counter(
     "yuptoo_host_uploaded",
-    "Total number of hosts uploaded to inventory",
-    ["org_id"]
+    "Total number of hosts uploaded to inventory"
 )
 
 host_upload_failures = Counter(
     "yuptoo_host_upload_failures",
-    "Total number of hosts failed to upload",
-    ["org_id"]
+    "Total number of hosts failed to upload"
 )
 
 kafka_failures = Counter(
     "yuptoo_kafka_failures",
-    "Total number of kafka failures while processing messages",
-    ["org_id"]
+    "Total number of kafka failures while processing messages"
 )
 
 incoming_hosts_counter = Counter(
     'yuptoo_incoming_hosts_counter',
     'Total number of hosts in report as per source',
-    ["org_id", "source"]
+    ["source"]
 )

--- a/yuptoo/lib/produce.py
+++ b/yuptoo/lib/produce.py
@@ -28,15 +28,11 @@ def send_message(kafka_topic, msg, request_obj=None):
         if err is not None:
             LOG.error(f"Message delivery for topic {msg.topic()} failed: {err}")
             if is_msg_for_hbi:
-                host_upload_failures.labels(
-                        org_id=request_obj['org_id']
-                    ).inc()
+                host_upload_failures.inc()
         else:
             if is_msg_for_hbi:
                 request_obj['host_inventory_upload_count'] += 1
-                host_uploaded.labels(
-                        org_id=request_obj['org_id']
-                    ).inc()
+                host_uploaded.inc()
             LOG.debug(f"Message delivered to {msg.topic()} [{msg.partition()}]")
 
     try:

--- a/yuptoo/processor/report_processor.py
+++ b/yuptoo/processor/report_processor.py
@@ -62,9 +62,7 @@ def process_report_slice(report_slice, request_obj):
             upload_to_host_inventory_via_kafka(host, request_obj)
         else:
             request_obj['hosts_without_facts'].append({report_slice.get('report_slice_id'): host['fqdn']})
-            host_upload_failures.labels(
-                org_id=request_obj['org_id']
-            ).inc()
+            host_upload_failures.inc()
 
 
 def log_report_summary(request_obj):

--- a/yuptoo/processor/utils.py
+++ b/yuptoo/processor/utils.py
@@ -53,7 +53,7 @@ def download_report(consumed_message):
         archive_downloaded_success.inc()
         return download_response.content
     except Exception as err:
-        archive_failed_to_download.labels(org_id=consumed_message.get('org_id')).inc()
+        archive_failed_to_download.inc()
         raise FailDownloadException(
             f"Unexpected error for URL {report_url}. Error: {err}"
         )

--- a/yuptoo/validators/report_metadata_validator.py
+++ b/yuptoo/validators/report_metadata_validator.py
@@ -61,7 +61,6 @@ def validate_metadata_file(tar, metadata, request_obj):
         else:
             invalid_slice_ids[report_slice_id] = num_hosts
     incoming_hosts_counter.labels(
-        org_id=request_obj['org_id'],
         source=request_obj['source']).inc(total_hosts_in_report)
 
     # if any reports were over the max number of hosts, we need to log


### PR DESCRIPTION
Org_id is an unnecessary label in all the metrics, It also increases the cardinality in metrics. 
If we need to get detailed info of report based on org_id we can get it from kibana logs.