### PR TITLE
Fixes #YUPTOO-53 - Truncate value for tags with more than 250 char

### DIFF
--- a/tests/modifiers/test_transform_tags.py
+++ b/tests/modifiers/test_transform_tags.py
@@ -44,3 +44,50 @@ def test_transform_tags_value_to_string():
 
     assert host == result
     assert 'tags' in transformed_obj['modified']
+
+
+def test_transform_tags_255_char():
+    """Test tags transformation for host for more than 255 char"""
+    host = {'tags': [
+        {
+            'namespace': 'satellite_parameter',
+            'key': 'host_registration_insights',
+            'value': "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc"
+                     "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc"
+                     "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc"
+        },
+        {
+            'namespace': 'satellite_parameter',
+            'key': 'host_registration_remote_execution',
+            'value': False
+        },
+        {
+            'namespace': 'satellite',
+            'key': 'organization_id',
+            'value': 1
+        }
+    ]}
+
+    transformed_obj = {'removed': [], 'modified': [], 'missing_data': []}
+    TransformTags().run(host, transformed_obj)
+
+    result = {'tags': [
+            {
+                'namespace': 'satellite_parameter',
+                'key': 'host_registration_insights',
+                'value': 'Truncated.Longer than maximum length 255.'
+            },
+            {
+                'namespace': 'satellite_parameter',
+                'key': 'host_registration_remote_execution',
+                'value': 'false'
+            },
+            {
+                'namespace': 'satellite',
+                'key': 'organization_id',
+                'value': '1'
+            }
+        ]}
+
+    assert host == result
+    assert 'tags' in transformed_obj['modified']

--- a/tests/modifiers/test_transform_tags.py
+++ b/tests/modifiers/test_transform_tags.py
@@ -46,8 +46,8 @@ def test_transform_tags_value_to_string():
     assert 'tags' in transformed_obj['modified']
 
 
-def test_transform_tags_255_char():
-    """Test tags transformation for host for more than 255 char"""
+def test_transform_tags_250_char():
+    """Test tags transformation for host for more than 250 char"""
     host = {'tags': [
         {
             'namespace': 'satellite_parameter',
@@ -75,7 +75,7 @@ def test_transform_tags_255_char():
             {
                 'namespace': 'satellite_parameter',
                 'key': 'host_registration_insights',
-                'value': 'Truncated.Longer than maximum length 255.'
+                'value': 'Original value exceeds 250 characters.'
             },
             {
                 'namespace': 'satellite_parameter',

--- a/yuptoo/modifiers/transform_tags.py
+++ b/yuptoo/modifiers/transform_tags.py
@@ -10,6 +10,7 @@ class TransformTags(Modifier):
 
                 if len(str(tag['value'])) > 250:
                     tag['value'] = "Original value exceeds 250 characters."
+                    tags_modified = True
 
                 if tag['value'] is None or isinstance(tag['value'], str):
                     continue

--- a/yuptoo/modifiers/transform_tags.py
+++ b/yuptoo/modifiers/transform_tags.py
@@ -8,8 +8,8 @@ class TransformTags(Modifier):
             tags_modified = False
             for tag in tags:
 
-                if len(str(tag['value'])) > 255:
-                    tag['value'] = "Truncated.Longer than maximum length 255."
+                if len(str(tag['value'])) > 250:
+                    tag['value'] = "Original value exceeds 250 characters."
 
                 if tag['value'] is None or isinstance(tag['value'], str):
                     continue

--- a/yuptoo/modifiers/transform_tags.py
+++ b/yuptoo/modifiers/transform_tags.py
@@ -7,6 +7,10 @@ class TransformTags(Modifier):
         if tags:
             tags_modified = False
             for tag in tags:
+
+                if len(str(tag['value'])) > 255:
+                    tag['value'] = "Truncated.Longer than maximum length 255."
+
                 if tag['value'] is None or isinstance(tag['value'], str):
                     continue
 
@@ -16,7 +20,6 @@ class TransformTags(Modifier):
                     tag['value'] = 'false'
                 else:
                     tag['value'] = str(tag['value'])
-
                 tags_modified = True
 
             if tags_modified:


### PR DESCRIPTION
Co-operated changes similar to foreman-rh-cloud, please refer https://github.com/theforeman/foreman_rh_cloud/blob/master/lib/foreman_inventory_upload/generators/tags.rb#L63.


+ adding @san7ket and @upadhyeammit in cc. Please request to review newly added changes.