### PR TITLE
Fixes #SWATCH-1814 - Enable smoke test result upload to Report Portal

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,6 +10,7 @@ export IQE_PLUGINS="foreman-rh-cloud"         # name of the IQE plugin for this 
 export IQE_MARKER_EXPRESSION="yupana_smoke"   # This is the value passed to pytest -m
 export IQE_FILTER_EXPRESSION=""               # This is the value passed to pytest -k
 export IQE_CJI_TIMEOUT="30m"                  # This is the time to wait for smoke test to complete or fail
+export IQE_PARALLEL_ENABLED="false"
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
@@ -20,6 +21,10 @@ source $CICD_ROOT/build.sh
 
 # Deploy to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# Enable smoke test results upload to report portal
+export IQE_RP_ARGS="true"
+export IQE_IBUTSU_SOURCE="yuptoo-ephemeral-${IMAGE_TAG}" 
 
 # Run smoke tests with ClowdJobInvocation
 source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
## Description

This PR is to enable upload of IQE test results to report portal. 

**Before:** 
`bonfire deploy-iqe-cji` command has `--rp-args ''\'''\''' --ibutsu-source ''\'''\'''`

**After:**
`bonfire deploy-iqe-cji` command has `--rp-args true --ibutsu-source yuptoo-ephemeral-pr-2621-51867ac`


### Verification
Check pr-check job has correct variable value for IQE_RP_ARGS="true" and IQE_IBUTSU_SOURCE with IMAGE_TAG. 