### PR TITLE
fix: correct fact name to insights_id

### DIFF
--- a/tests/processor/test_utils.py
+++ b/tests/processor/test_utils.py
@@ -34,7 +34,7 @@ def test_download_report_without_url():
 
 
 def test_has_canonical_facts_true():
-    host = {'insights_client_id': '123'}
+    host = {'insights_id': '123'}
     result = has_canonical_facts(host)
     assert result is True
 

--- a/yuptoo/processor/utils.py
+++ b/yuptoo/processor/utils.py
@@ -25,7 +25,7 @@ def print_transformed_info(request_obj, host_id, transformed_obj):
 
 
 def has_canonical_facts(host):
-    CANONICAL_FACTS = ['insights_client_id', 'bios_uuid', 'ip_addresses', 'mac_addresses',
+    CANONICAL_FACTS = ['insights_id', 'bios_uuid', 'ip_addresses', 'mac_addresses',
                        'vm_uuid', 'etc_machine_id', 'subscription_manager_id']
     for fact in CANONICAL_FACTS:
         if host.get(fact):


### PR DESCRIPTION
Since Yupana repository [here](https://github.com/quipucords/yupana/blob/master/yupana/processor/abstract_processor.py#L48), fact name was referred as `insights_client_id` not `insights_id`.
Everywhere, fact name *is referred as `insights_id`. 
It seems a hidden bug that never encountered, may be because any of the rest fact is always present.