### PR TITLE
fix: image reference path in docs

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,11 +5,11 @@ A client(rh-cloud-plugin/satellite) will create a specially crafted tarball and 
 https://github.com/RedHatInsights/yuptoo[Code Repository]
 
 == Architectural Diagram
-image::yuptoo.png[]
+image::../images/yuptoo.png[]
 
 == How It Works
 The following sequence diagram shows the data flow and processing of payload recevied on `platform.upload.announce` kafka topic.
 
-image::sequence_diagram.png[]
+image::../images/sequence_diagram.png[]
 
 ---


### PR DESCRIPTION
support [RHINENG-1487](https://issues.redhat.com/browse/RHINENG-1487) better

Currently, the doc's images reference in github repo view is broken due to the wrong path.
Meanwhile, the [ConsoleDot Page doc](https://consoledot.pages.redhat.com/yuptoo/dev/index.html) (which relied on the github doc) can show the images correctly. 

Correct the wrong image path references in github repo view.