### PR TITLE
Revert "Refs #RHINENG-2640 - set reporter to "discovery" or "satellite" (#71)"

### DIFF
--- a/tests/modifiers/test_add_host_facts.py
+++ b/tests/modifiers/test_add_host_facts.py
@@ -16,7 +16,6 @@ def test_add_host_facts():
                    'report_platform_id': '123', 'source': 'satellite', 'request_id': uuid1}
     AddHostFacts().run(host, transformed_obj, request_obj=request_obj)
     assert host['facts'][0]['namespace'] == 'yupana'
-    assert host['reporter'] == 'satellite'
     assert 'facts' in transformed_obj['modified']
 
 

--- a/yuptoo/modifiers/add_host_facts.py
+++ b/yuptoo/modifiers/add_host_facts.py
@@ -39,7 +39,7 @@ class AddHostFacts(Modifier):
             yuptoo_facts['facts']['account'] = request_obj['account']
         host_facts.append(yuptoo_facts)
         host['stale_timestamp'] = self.get_stale_time(request_obj)
-        host['reporter'] = 'discovery' if request_obj['source'] == "discovery" else 'satellite'
+        host['reporter'] = 'yupana'
         host['facts'] = host_facts
         if cert_cn and ('system_profile' in host):
             host['system_profile']['owner_id'] = cert_cn


### PR DESCRIPTION

This reverts commit f8d6ddeac01c77fae0171ba24d4c658146b98a3c.

Revert this feat to not block the release of the later commits in main branch.
Need to release the updates to fix RHINENG-9577 