### PR TITLE
fix: ci codecov error

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint with flake8
         run: |
             pipenv run flake8
-    
+
     Test:
       runs-on: ubuntu-latest
 
@@ -57,8 +57,10 @@ jobs:
             pipenv run python -m pytest --cov=yuptoo tests
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
           flags: unittests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
update to use codecov/codecov-action@v4 with CODECOV_TOKEN

error e.g. https://github.com/RedHatInsights/yuptoo/actions/runs/8779939178/job/24089042123?pr=75 

fix RHINENG-9598