### PR TITLE
Update clowdapp.yaml to add testing block with iqe plugin

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -10,6 +10,8 @@ objects:
     name: yuptoo
   spec:
     envName: ${ENV_NAME}
+    testing:
+      iqePlugin: foreman-rh-cloud
     dependencies:
     - ingress
     - host-inventory


### PR DESCRIPTION
This should help tekton pipeline pick correct plugin image, even without specifying the image tag