### PR TITLE
fix: use konflux image

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -52,7 +52,7 @@ parameters:
 - description: Image NAME
   name: IMAGE
   required: true
-  value: quay.io/cloudservices/yuptoo
+  value: quay.io/redhat-services-prod/insights-management-tenant/insights-yuptoo/yuptoo
 - description: Image tag
   name: IMAGE_TAG
   required: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+    "extends": [
+        "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    ],
+    "schedule": [
+        "on Monday after 3am and before 10am"
+    ],
+    "ignorePaths": [
+      ".pre-commit-config.yaml"
+    ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -9,3 +9,4 @@
       ".pre-commit-config.yaml"
     ]
 }
+


### PR DESCRIPTION
In the https://github.com/RedHatInsights/yuptoo/pull/107 , the Konflux pull request CI seems was not triggered in Konflux, no [record](https://console.redhat.com/application-pipeline/workspaces/insights-management/applications/insights-yuptoo/activity/latest-commits) for that PR in Konflux. And the re-runaction in github side triggered nothing to Konflux pipeline: `Red Hat Konflux Failing after 2596m — pipelinerun start failure`  

Re-open for PR https://github.com/RedHatInsights/yuptoo/pull/107 to try to re-trigger the connection for Konflux pull request CI .  