### PR TITLE
RHINENG-19294: bump up pkgs with hermetic build enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ WORKDIR $APP_ROOT/src/
 RUN set -ex && if [ -e `which python3.11` ]; then ln -s `which python3.11` /usr/local/bin/python; fi
 
 # Download and install librdkafka
-RUN curl -L https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.10.1.zip -o /tmp/librdkafka.zip || cp /cachi2/output/deps/generic/v2.10.1.zip /tmp/librdkafka.zip && \
+RUN curl -L https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.0.zip -o /tmp/librdkafka.zip || cp /cachi2/output/deps/generic/v2.11.0.zip /tmp/librdkafka.zip && \
     unzip /tmp/librdkafka.zip -d /tmp && \
-    cd /tmp/librdkafka-2.10.1 && \
+    cd /tmp/librdkafka-2.11.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [packages]
 app-common-python = "==0.2.8"
 confluent-kafka = "*"
-insights-core = "==3.5.4"
+insights-core = "==3.6.2"
 logstash-formatter = "*"
 prometheus-client = "*"
 requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e9724c8752a6fa1e819a96730da030421e6e967318431f9dc5bbc8e1ab88029"
+            "sha256": "22ee094cae2f97e8f7f75d8237f3daf554e86faf2734d45e4322564ee2fd5c18"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2e3411bb43285caad1c8e1a3186d025ba65a6342e26bad493f6b8feb3d1a1680",
-                "sha256:9b0ff0b34c9cf7328546c532c20b081f09055ff485f4d57c19146c36877048c5"
+                "sha256:82c6868cad18c3bd4170915e9525f9af5f83e9779c528417f8863629558fc2d0",
+                "sha256:fabb16360a93b449d5241006485bcc761c26694e75ac01009f4459f114acc06e"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.43"
+            "version": "==1.39.14"
         },
         "botocore": {
             "hashes": [
-                "sha256:2ee60ac0b08e80e9be2aa2841d42e438d5bc4f82549560a682837655097a3db7",
-                "sha256:c453c5c16c157c5427058bb3cc2c5ad35ee2e43336f0ccbfcc6092c5635505c6"
+                "sha256:4ed551c77194167b7e8063f33059bc2f9b2ead0ed4ee33dc7857273648ed4349",
+                "sha256:7fc44d4ad13b524e5d8a6296785776ef5898ac026ff74df9b35313831d507926"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.43"
+            "version": "==1.39.14"
         },
         "cachecontrol": {
             "extras": [
@@ -54,11 +54,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
+                "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.14"
         },
         "charset-normalizer": {
             "hashes": [
@@ -160,45 +160,45 @@
         },
         "confluent-kafka": {
             "hashes": [
-                "sha256:07c3cf9f75b22924bca777a26640902c2675bc70a33172f1354a47ebe70d7f1e",
-                "sha256:08aef1602a5dd2fc448dac5009b345d93304d8ab53640c8a63f06714f4420294",
-                "sha256:0addf6fe866ade4d13f94057a6908dff7ddec7d68002a3f6b596bc72d975ed8b",
-                "sha256:147c83ea89b0e93ecc7dac6d42eebc4fc541cfb1f0f7d8ab05fdda76b7d7adcc",
-                "sha256:29569d5185fad1903b8dd34cbc3b16649425da4346749dd567b87298e733cad3",
-                "sha256:2a2db485bdd6186334587833b5aea8489109c388cd9f8c44eeb146013086a3c3",
-                "sha256:2b7e85876c8b714e20a54cdc313509767885d00b9ced3cbff2285d881853151b",
-                "sha256:325b774ebf37d5d5e7fdcda58bea2925c5bf536da365db0e80e4e3e1d1e4b748",
-                "sha256:33c2ca92920d0c7e5079f9814523ed709b16d369ab0cca1941abc72b703a8c59",
-                "sha256:352152e0562a5feb2fa4ec4f91b801fed56695f5508946ff084aa23b4495b201",
-                "sha256:3a10d099efbdddd58d71172db50de784991c4f2d47a55c09e5023e943aef88bf",
-                "sha256:536c76f6c39a93c367a70016781cf7e73808300228b8e33b444c846fdef801e4",
-                "sha256:55c2c78d0d3ab37f325acac38322a2d50f409eadf7057619c1b58941f28ceff5",
-                "sha256:682b67ec638142fe090e71f76d698484d3199e70b67474e16938c196e635fa4b",
-                "sha256:707d07b56b31442633123504ba6542cf6a9683bdd256b89dec3687afdd7b1f4a",
-                "sha256:77e0c20b7d14c44c9623ea92b136255670d2d91903828e8cf93cacf11e90c166",
-                "sha256:8a2dff853423789c1b0ec91e4c98d54ebaa87a72862ca5945d385036132b0929",
-                "sha256:8a6f3acfac7931558d76e5aea0552f2d4f833c04ac8214604f4e3d0cb2ee0b59",
-                "sha256:95d72e1b9576bc4cd269dbba0dda65047d316ff2fab84c88aa3417f2a3aae0b6",
-                "sha256:9c4282213d9066ba37d5508d01c1e1e63963f4ea2273d918ebcf8990311347ad",
-                "sha256:9fdf9efcbe290bb2d08ed8ac682987438d771600a036f6246f3be03244a09504",
-                "sha256:a277eec260fd048cfcc32a95da9e14e0701d7c04b276dcc79de7f09fdfa74235",
-                "sha256:a7724d6fb4526240980fcae7900c62ffb93ce5c5926a4e19133ec79e26558b61",
-                "sha256:ad6a9ba5aba014b3a45d560edccd8864be5cc4a9402ba8520201b18c18b7c899",
-                "sha256:b03a534c11969b02b989a876dfef483dba2cd6edd8014dda904158e678ddb4f4",
-                "sha256:b8040e89e89d462331fc5c46d6f6b79d22f1b9482afc8005776029965b86b41c",
-                "sha256:be21c9a4bf8da98440e7999701587d87f13e4a342c761711e6c12fb5d8ef0371",
-                "sha256:d2190269874554e5b2dd8b8d08968d3f205107fbe58c7199bde7c89aabeabff2",
-                "sha256:d5303e42f94fc044e27e0224476173fe454d039f7cad5011bae5775086161c23",
-                "sha256:deb4d95114ada2020abc24b48c3861dd96f164955652e7bd9f9b8e84b257c03a",
-                "sha256:edfd39d73fc8d276c058a562b7815d25b7427c6be75bdb914920fba067673591",
-                "sha256:f17b45fcdecf0d58c584d5ae95257078759796aaed73ebbe1d32431228c50467",
-                "sha256:f3aec168ec1817d89102e0d517f8523fc7efbf0058859dcf5aa42cd9d99a12fa",
-                "sha256:f56b51685c017b46a45f2f1f5ab283b594d433572aecf3463ecca600188bf3c9",
-                "sha256:fdd032a8c7637263defcf577b36d1d4dba6495877e49662e4af4cc15e6950c77"
+                "sha256:02e383dcc6174512851add8c5bd17987fb2bfa4dc94b3646158d0a6be2b95683",
+                "sha256:08e0b0b7fb21ddd83801231f5f32b7e7ba4f7c9a7dee9034a1e36e6b6479143a",
+                "sha256:0e5f5ebe3742f2bb430d437f5f1b3539e0648e598af590c9f7d588e21d7297e1",
+                "sha256:10ec391ed179cb613d7e4961a59fa9f0d6112e2753ceef1cd6bd03bc7c5cec24",
+                "sha256:1249f9aab62317c274d41d74c32883744d1b157f846961c97266c42a30ceaa29",
+                "sha256:18dd7ab3ffedae4b7f5668641da317a514284f50b2544d58c9b59d921bfb4c0a",
+                "sha256:1ac35a551c8df8313695bff3e81dd8ef3d9041b0edc8827883ef8015819bc59c",
+                "sha256:2552147d0929db95ace291e460c652981721e0e437a074445fbafdcee8b6817c",
+                "sha256:2effcccd28677f918ef879e7112cb15492004a50fd3ec92c330df5b420597283",
+                "sha256:2f54f077904cc8541be03e16bee9bf37207c96e6bbd3c5b3d1b5fbd878e40580",
+                "sha256:360e74b6970ec699dad934a951e82a1553926cb2f8a2aa772f582ba48a9ad4e1",
+                "sha256:39b4ee51d16804bfa8674c0d07b785259d48f051def5f681f501bab5f110e304",
+                "sha256:455a368d35dc4444d4d8f442b5715e3b43310b60bb0f99837556830bd32defdf",
+                "sha256:56b0adf6c2558624c3166a49b518e86059369153be15e62e113335db24438f82",
+                "sha256:5dccc94019fbca33bcc49d993641b7145c448255206480a38eee452869653b33",
+                "sha256:655b5d3a90955dd4ee15e59d89f33b5eaae14e7122e9fecb93b4c03ef426ec97",
+                "sha256:6d6ec6e791b1c97668ff0823dff1dc005ab418b353a430fede7b5cd6c5490497",
+                "sha256:6dc952c45108351b3995b85e23d99c2251a5160e3ed3d9a7768300d8c97eca56",
+                "sha256:70682b25b5ce835de54b6eb803a75e550a953e494fe348960ed8c534cb54ea50",
+                "sha256:707d7a39755986605402dd308013e6a142b8a5105d51f863b17f4bc283f4ac85",
+                "sha256:7ab9b40866d783cd410019b0380b0db815ac36ecf07be2be80a429e41d7caf98",
+                "sha256:7c295323f8eecf7f70e570435964d28729190dc52412ba5a4068862ac20e7d9a",
+                "sha256:80edbdf59d312772a4c5646807cb2a0b5f5a2c7f945df070aac1782a7790f432",
+                "sha256:854ec3d904001a74cda309038783a4538e1032ee5f2e683738c9b1159622e437",
+                "sha256:90c27e2bef0cf3812984bde02925a1edda9e700650d903c7cdce1fc60946e373",
+                "sha256:9f44a476241a81e6b3259d3f3f00aa0e94ed64a924131f83cb3b640ecdfcd633",
+                "sha256:a13398b5b6e025e710b3123c17db8dbc4db78c708916bb602211257fcd7f27c8",
+                "sha256:a29ac34c7dd3ab51c2e7cc16c37baed13369a487d7f953ff4e3a8fff08642969",
+                "sha256:ae672723577775aba560da34e376ffa4a038ff3e07c8513920b81903f8f9c4e8",
+                "sha256:be6273ae93a9076c28ccda39dacae98405af696c97bab02a8a78abd02fe3add4",
+                "sha256:d38deb0163c641021100a4cac5bef9ddc3949c51df8ce15b063850010ff64dff",
+                "sha256:d95512838eebd42a4657ce891dfa32bcbc06906e3391b328de24f7731b0c2755",
+                "sha256:e58b263d8e02c54396e7159d2d6668c9e6f2e7faa06c40026df205ff81b6188e",
+                "sha256:ed0981e686bdc4ee86034113a750242fe1b405826bf4a553498bf558429188af",
+                "sha256:fc8346a55c4b3f4e4ed938243997e3223e0f00c93c48d52a86343943c0316a6c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.10.1"
+            "version": "==2.11.0"
         },
         "defusedxml": {
             "hashes": [
@@ -226,11 +226,12 @@
         },
         "insights-core": {
             "hashes": [
-                "sha256:1ecbbe430dd8ea362b112591d289cd3a9b223dc58c350cdd5562a7e177cb423e",
-                "sha256:2031d51a3687a428cf2838e8568aa0c9abad223d49adfbd9c3bc429d6704bbbf"
+                "sha256:379b8f1445ba699c483d6710c849185be2ab915d5383252daeed6650fdce5a03",
+                "sha256:65305960c515859ff6a89240c7f7f49d7d281f246d394ac4fde60e52559adbd1"
             ],
             "index": "pypi",
-            "version": "==3.5.4"
+            "markers": "python_version >= '2.7'",
+            "version": "==3.6.2"
         },
         "jinja2": {
             "hashes": [
@@ -489,11 +490,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be",
-                "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"
+                "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724",
+                "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "six": {
             "hashes": [
@@ -527,76 +528,97 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71",
-                "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338",
-                "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0",
-                "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f",
-                "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5",
-                "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509",
-                "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c",
-                "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d",
-                "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f",
-                "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1",
-                "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8",
-                "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683",
-                "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e",
-                "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631",
-                "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43",
-                "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67",
-                "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed",
-                "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875",
-                "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029",
-                "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7",
-                "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385",
-                "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10",
-                "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58",
-                "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55",
-                "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb",
-                "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74",
-                "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300",
-                "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d",
-                "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643",
-                "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c",
-                "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363",
-                "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed",
-                "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d",
-                "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e",
-                "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125",
-                "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec",
-                "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951",
-                "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70",
-                "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751",
-                "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f",
-                "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5",
-                "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd",
-                "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d",
-                "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d",
-                "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582",
-                "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898",
-                "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7",
-                "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c",
-                "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe",
-                "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626",
-                "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342",
-                "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece",
-                "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86",
-                "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3",
-                "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a",
-                "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b",
-                "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca",
-                "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187",
-                "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b",
-                "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86",
-                "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514",
-                "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32",
-                "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244",
-                "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250",
-                "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce",
-                "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd",
-                "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3"
+                "sha256:042125c89cf74a074984002e165d61fe0e31c7bd40ebb4bbebf07939b5924613",
+                "sha256:083442ecf97d434f0cb3b3e3676584443182653da08b42e965326ba12d6b5f2a",
+                "sha256:1217a54cfd79be20512a67ca81c7da3f2163f51bbfd188aab91054df012154f5",
+                "sha256:166d89c57e877e93d8827dac32cedae6b0277ca684c6511497311249f35a280c",
+                "sha256:1a108dd78ed185020f66f131c60078f3fae3f61646c28c8bb4edd3fa121fc7fc",
+                "sha256:1aadfb06a30c62c2eb82322171fe1f7c288c80ca4156d46af0ca039052814bab",
+                "sha256:1c4f679c6b573a5257af6012f167a45be4c749c9925fd44d5178fd641ad8bf72",
+                "sha256:1c86eb388bbd609d15560e7cc0eb936c102b6f43f31cf3e58b4fd9afe28e1372",
+                "sha256:1e0c768b0f9ac5839dac5cf88992a4bb459e488ee8a1f8489af4cb33b1af00f1",
+                "sha256:21eb7d8b45d3700e7c2936a736f732794c47615a20f739f4133d5230a6512a88",
+                "sha256:2348631f049e884839553b9974f0821d39241c6ffb01a418efce434f7eba0fe7",
+                "sha256:283005bb4d98ae33e45f2861cd2cde6a21878661c9ad49697f6951b358a0379b",
+                "sha256:2b225a06d227f23f386fdc0eab471506d9e644be699424814acc7d114595495f",
+                "sha256:320d86da829b012982b414c7cdda65f5d358d63f764e0e4e54b33097646f39a3",
+                "sha256:37b69226001d8b7de7126cad7366b0778d36777e4d788c66991455ba817c5b41",
+                "sha256:3a7a4d74cb0f5e3334f9aa26af7016ddb94fb4bfa11b4a573d8e98ecba8c34f1",
+                "sha256:3beb76e20b28046989300c4ea81bf690df84ee98ade4dc0bbbf774a28eb98440",
+                "sha256:3e31dfb8271937cab9425f19259b1b1d1f556790e98eb266009e7a61d337b6d4",
+                "sha256:3e59d00830da411a1feef6ac828b90bbf74c9b6a8e87b8ca37964925bba76dbe",
+                "sha256:4072b31361b0d6d23f750c524f694e1a417c1220a30d3ef02741eed28520c48e",
+                "sha256:40f9a38676f9c073bf4b9194707aa1eb97dca0e22cc3766d83879d72500132c7",
+                "sha256:47ab6dbbc31a14c5486420c2c1077fcae692097f673cf5be9ddbec8cdaa4cdbc",
+                "sha256:47c91f32ba4ac46f1e224a7ebf3f98b4b24335bad16137737fe71a5961a0665c",
+                "sha256:4fcfe294f95b44e4754da5b58be750396f2b1caca8f9a0e78588e3ef85f8b8be",
+                "sha256:5121d8cf0eacb16133501455d216bb5f99899ae2f52d394fe45d59229e6611d0",
+                "sha256:51f30da7a52c009667e02f125737229d7d8044ad84b79db454308033a7808ab2",
+                "sha256:51fe93f3fe4f5d8483d51072fddc65e717a175490804e1942c975a68e04bf97a",
+                "sha256:57b6e8789cbefdef0667e4a94f8ffa40f9402cee5fc3b8e4274c894737890145",
+                "sha256:590bdba9445df4763bdbebc928d8182f094c1f3947a8dc0fc82ef014dbdd8324",
+                "sha256:5ba9a8770effec5baaaab1567be916c87d8eea0c9ad11253722d86874d885eca",
+                "sha256:607f82389f0ecafc565813aa201a5cade04f897603750028dd660fb01797265e",
+                "sha256:6b4ba0f488c1bdb6bd9ba81da50715a372119785458831c73428a8566253b86b",
+                "sha256:6b7dc7f0a75a7eaa4584e5843c873c561b12602439d2351ee28c7478186c4da4",
+                "sha256:7092cc82382e634075cc0255b0b69cb7cada7c1f249070ace6a95cb0f13548ef",
+                "sha256:7718060dd4434cc719803a5e526838a5d66e4efa5dc46d2b25c21965a9c6fcc4",
+                "sha256:780f750a25e7749d0af6b3631759c2c14f45de209f3faaa2398312d1c7a22759",
+                "sha256:7f39edd52c23e5c7ed94e0e4bf088928029edf86ef10b95413e5ea670c5e92d7",
+                "sha256:80b9ccd82e30038b61fc9a692a8dc4801504689651b281ed9109f10cc9fe8b4d",
+                "sha256:85b22a9cce00cb03156334da67eb86e29f22b5e93876d0dd6a98646bb8a74e53",
+                "sha256:871ebe8143da284bd77b84a9136200bd638be253618765d21a1fce71006d94af",
+                "sha256:89ec0ffc215c590c732918c95cd02b55c7d0f569d76b90bb1a5e78aa340618e4",
+                "sha256:924563481c27941229cb4e16eefacc35da28563e80791b3ddc5597b062a5c386",
+                "sha256:97b6983a2f9c76d345ca395e843a049390b39652984e4a3b45b2442fa733992d",
+                "sha256:991196702d5e0b120a8fef2664e1b9c333a81d36d5f6bcf6b225c0cf8b0451a2",
+                "sha256:998c4751dabf7d29b30594af416e4bf5091f11f92a8d88eb1512c7ba136d1ed7",
+                "sha256:9b2df80cb6a2af86d300e70acb82e9b79dab2c1e6971e44b78dbfc1a1e736b53",
+                "sha256:9d6f494c307e5cb9b1e052ec1a471060f1dea092c8116e642e7a23e79d9388ea",
+                "sha256:9eb245a8d8dd0ad73b4062135a251ec55086fbc2c42e0eb9725a9b553fba18a3",
+                "sha256:a22c3bfe09f7a530e2c94c87ff7af867259c91bef87ed2089cd69b783af7b84e",
+                "sha256:aa309df995d020f3438407081b51ff527171cca6772b33cf8f85344b8b4b8770",
+                "sha256:ab6e19b684981d0cd968906e293d5628e89faacb27977c92f3600b201926b994",
+                "sha256:ac0c5bba938879c2fc0bc6c1b47311b5ad1212a9dcb8b40fe2c8110239b7faed",
+                "sha256:ae2b4856f29ddfe827106794f3589949a57da6f0d38ab01e24ec35107979ba57",
+                "sha256:ae8e59e5f4fd85d6ad34c2bb9d74037b5b11be072b8b7e9986beb11f957573d4",
+                "sha256:b2f22102197bcb1722691296f9e589f02b616f874e54a209284dd7b9294b0b7f",
+                "sha256:b45e2f9d5b0b5c1977cb4feb5f594be60eb121106f8900348e29331f553a726f",
+                "sha256:bc265a7945e8d08da28999ad02b544963f813a00f3ed0a7a0ce4165fd77629f8",
+                "sha256:bed4a2341b33cd1a7d9ffc47df4a78ee61d3416d43b4adc9e18b7d266650b83e",
+                "sha256:c1a40c486041006b135759f59189385da7c66d239bad897c994e18fd1d0c128f",
+                "sha256:c36baa0ecde742784aa76c2b816466d3ea888d5297fda0edbac1bf48fa94688a",
+                "sha256:c4c746d11c8aba4b9f58ca8bfc6fbfd0da4efe7960ae5540d1a1b13655ee8892",
+                "sha256:ca79146ee421b259f8131f153102220b84d1a5e6fb9c8aed13b3badfd1796de6",
+                "sha256:cc452481e124a819ced0c25412ea2e144269ef2f2534b862d9f6a9dae4bda17b",
+                "sha256:cfb8b9d8855c8608f9747602a48ab525b1d320ecf0113994f6df23160af68262",
+                "sha256:d12b15a8c3759e2bb580ffa423ae54be4f184cf23beffcbd641f4fe6e1584293",
+                "sha256:d24fb3c0c8ff0d517c5ca5de7cf3994a4cd559cde0315201511dbfa7ab528894",
+                "sha256:d4b0aab55ad60ead26159ff12b538c85fbab731a5e3411c642b46c3525863437",
+                "sha256:d6a558c2725bfb6337bf57c1cd366c13798bfd3bfc9e3dd1f4a6f6fc95a4605f",
+                "sha256:d946a0c067aa88be4a593aad1236493313bafaa27e2a2080bfe88db827972f3c",
+                "sha256:dc60ddd483c556590da1d9482a4518292eec36dd0e1e8496966759a1f282bcd0",
+                "sha256:dcc93488c9ebd229be6ee1f0d9aad90da97b33ad7e2912f5495804d78a3cd6b7",
+                "sha256:ddca1e4f5f4c67980533df01430184c19b5359900e080248bbf4ed6789584d8b",
+                "sha256:ddf2a63b91399a1c2f88f40bc1705d5a7777e31c7e9eb27c602280f477b582ba",
+                "sha256:df1c742ca6f46a6f6cbcaef9ac694dc2cb1260d30a6a2f5c68c5f5bcfee1cfd7",
+                "sha256:e37c72eaccdd5ed1130c67a92ad38f5b2af66eeff7b0abe29534225db2ef7b18",
+                "sha256:e58991a2b213417285ec866d3cd32db17a6a88061a985dbb7e8e8f13af429c47",
+                "sha256:e6150d167f32f2a54690e572e0a4c90296fb000a18e9b26ab81a6489e24e78dd",
+                "sha256:e88dd71e4ecbc49d9d57d064117462c43f40a21a1383507811cf834a4a620651",
+                "sha256:e8ab8e4c7ec7f8a55ac05b5b715a051d74eac62511c6d96d5bb79aaafa3b04cf",
+                "sha256:ebb08d0867c5a25dffa4823377292a0ffd7aaafb218b5d4e2e106378b1061e39",
+                "sha256:ed3718c757c82d920f1c94089066225ca2ad7f00bb904cb72b1c39ebdd906ccb",
+                "sha256:ee6be07af68d9c4fca4027c70cea0c31a0f1bc9cb464ff3c84a1f916bf82e652",
+                "sha256:efa23166da3fe2915f8ab452dde40319ac84dc357f635737174a08dbd912980c",
+                "sha256:f32a95a83c2e17422f67af922a89422cd24c6fa94041f083dd0bb4f6057d0bc7",
+                "sha256:f7da31a1ba31f1c1d4d5044b7c5813878adae1f3af8f4052d679cc493c7328f4",
+                "sha256:fa2a258aa6bf188eb9a8948f7102a83da7c430a0dce918dbd8b60ef8fcb772d7",
+                "sha256:fc0e46d86905ddd16b85991f1f4919028092b4e511689bbdaff0876bd8aab3dd",
+                "sha256:fefe31d61d02a8b2c419700b1fade9784a43d726de26495f243b663cd9fe1513"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.9.1"
+            "version": "==7.10.1"
         },
         "flake8": {
             "hashes": [

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -2,6 +2,6 @@
 metadata:
   version: "1.0"
 artifacts:
-  - download_url: "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.10.1.zip"
-    checksum: "sha256:7cb72c4f3d162f50d30d81fd7f7ba0f3d9e8ecd09d9b4c5af7933314e24dd0ba"
-    filename: "v2.10.1.zip"
+  - download_url: "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.0.zip"
+    checksum: "sha256:9e76a408f0ed346f21be5e2df58b672d07ff9c561a5027f16780d1b26ef24683"
+    filename: "v2.11.0.zip"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -181,9 +181,9 @@ types-setuptools==80.9.0.20250529 \
     --hash=sha256:00dfcedd73e333a430e10db096e4d46af93faf9314f832f13b6bbe3d6757e95f \
     --hash=sha256:79e088ba0cba2186c8d6499cbd3e143abb142d28a44b042c28d3148b1e353c91
     # via mypy
-typing-extensions==4.14.0 \
-    --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \
-    --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
+typing-extensions==4.14.1 \
+    --hash=sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36 \
+    --hash=sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76
     # via
     #   mypy
     #   setuptools-scm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 -i https://pypi.org/simple
 app-common-python==0.2.8
-boto3==1.38.43; python_version >= '3.9'
-botocore==1.38.43; python_version >= '3.9'
+boto3==1.39.14; python_version >= '3.9'
+botocore==1.39.14; python_version >= '3.9'
 cachecontrol[filecache,redis]==0.14.3; python_version >= '3.9'
-certifi==2025.6.15; python_version >= '3.7'
+certifi==2025.7.14; python_version >= '3.7'
 charset-normalizer==3.4.2; python_version >= '3.7'
-confluent-kafka==2.10.1; python_version >= '3.7'
+confluent-kafka==2.11.0; python_version >= '3.7'
 defusedxml==0.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 filelock==3.18.0; python_version >= '3.9'
 idna==3.10; python_version >= '3.6'
-insights-core==3.5.4
+insights-core==3.6.2; python_version >= '2.7'
 jinja2==3.1.6; python_version >= '3.7'
 jmespath==1.0.1; python_version >= '3.7'
 lockfile==0.12.2
@@ -21,7 +21,7 @@ python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in 
 pyyaml==6.0.2; python_version >= '3.8'
 redis==6.2.0; python_version >= '3.9'
 requests==2.32.4; python_version >= '3.8'
-s3transfer==0.13.0; python_version >= '3.9'
+s3transfer==0.13.1; python_version >= '3.9'
 six==1.17.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 urllib3==2.5.0; python_version >= '3.9'
 watchtower==3.4.0; python_version >= '3.8'

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -39,13 +39,13 @@ arches:
     name: glibc-headers
     evr: 2.34-168.el9_6.20
     sourcerpm: glibc-2.34-168.el9_6.20.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.25.1.el9_6.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.28.1.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 3688625
-    checksum: sha256:334de7e7a497b3e3e41a93143cf0b39ba7b7645e7572fe29c51072e1004779d6
+    size: 3693985
+    checksum: sha256:37205edddcd0914c54aaf2fb2c520facd55905331b9571e3e0f6799758fdcb3a
     name: kernel-headers
-    evr: 5.14.0-570.25.1.el9_6
-    sourcerpm: kernel-5.14.0-570.25.1.el9_6.src.rpm
+    evr: 5.14.0-570.28.1.el9_6
+    sourcerpm: kernel-5.14.0-570.28.1.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 66075


### PR DESCRIPTION
 - bump insights-core from 3.5.4 to 3.6.2