### PR TITLE
fix: pin the ubi base image to a fixed tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1752587672
+
 
 # Install dependencies, including runtime libraries
 RUN microdnf install --setopt=tsflags=nodocs -y python3.11 python3.11-pip python3.11-devel which gcc gcc-c++ make zlib zlib-devel openssl-libs openssl-devel libzstd libzstd-devel zip && \


### PR DESCRIPTION
- to resolve the konflux image build error on rpm packages dependency issue. The rpm packages versions be locked for Konflux hermetic builds enablement, yet, the rpms.lock.yaml was originally generated based on the ubi base image. Using the latest tag of base image, the konflux image build may fail randomly when there are base image updating.
 - the base image tag will be updated intentionally when required


## To resolve:

Yuptoo Konflux image build ci failed on rpm package installation dependency issues - [yuptoo-on-pull-request-mpkx9](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/insights-management-tenant/applications/insights-yuptoo/pipelineruns/yuptoo-on-pull-request-mpkx9/logs) of https://github.com/RedHatInsights/yuptoo/pull/177 :
```
[2025-08-07T18:04:52,573456708+00:00] ip link set lo up && buildah build --volume /tmp/cachi2:/cachi2 --volume /var/workdir/fetched.repos.d:/etc/yum.repos.d --pull=never --security-opt=unmask=/proc/interrupts --label build-date=2025-08-07T18:04:52 --label architecture=x86_64 --label vcs-type=git --label vcs-ref=91042495ec3f471bcc864afcb2b2bf99439b7aaf --label quay.expires-after=5d --tls-verify=true --no-cache --ulimit nofile=4096:4096 -f /tmp/Dockerfile.w1KrCq -t quay.io/redhat-user-workloads/insights-management-tenant/insights-yuptoo/yuptoo:on-pr-91042495ec3f471bcc864afcb2b2bf99439b7aaf .
STEP 1/19: FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
STEP 2/19: RUN . /cachi2/cachi2.env &&     microdnf install --setopt=tsflags=nodocs -y python3.11 python3.11-pip python3.11-devel which gcc gcc-c++ make zlib zlib-devel openssl-libs openssl-devel libzstd libzstd-devel zip &&     microdnf upgrade -y &&     microdnf clean all

(microdnf:224): librhsm-WARNING **: 18:04:52.879: Found 0 entitlement certificates

(microdnf:224): librhsm-WARNING **: 18:04:52.880: Found 0 entitlement certificates
error: Could not depsolve transaction; 2 problems detected:
 Problem 1: package gcc-11.5.0-5.el9_5.x86_64 from ubi-9-for-x86_64-appstream-rpms requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
  - conflicting requests
  - nothing provides glibc = 2.34-168.el9_6.20 needed by glibc-devel-2.34-168.el9_6.20.x86_64 from ubi-9-for-x86_64-appstream-rpms
 Problem 2: package gcc-c++-11.5.0-5.el9_5.x86_64 from ubi-9-for-x86_64-appstream-rpms requires gcc = 11.5.0-5.el9_5, but none of the providers can be installed
  - package gcc-11.5.0-5.el9_5.x86_64 from ubi-9-for-x86_64-appstream-rpms requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
  - conflicting requests
  - nothing provides glibc = 2.34-168.el9_6.20 needed by glibc-devel-2.34-168.el9_6.20.x86_64 from ubi-9-for-x86_64-appstream-rpms
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN . /cachi2/cachi2.env &&     microdnf install --setopt=tsflags=nodocs -y python3.11 python3.11-pip python3.11-devel which gcc gcc-c++ make zlib zlib-devel openssl-libs openssl-devel libzstd libzstd-devel zip &&     microdnf upgrade -y &&     microdnf clean all": exit status 1
step-prepare-sboms :-
2025/08/07 18:04:53 Skipping step because a previous step failed
```

These rpm packages have version locked via [rpms.lock.yaml](https://github.com/RedHatInsights/yuptoo/blob/main/rpms.lock.yaml) along with the Konflux hermetic builds enablement( [yuptoo/pull/155](https://github.com/RedHatInsights/yuptoo/pull/155) ). 

As the rpms.lock.yaml was originally generated based on the ubi base image, with the base image `latest` tag updating, konflux image build may fails randomly, eg. the konflux image build failure above.

## Summary by Sourcery

Pin the UBI base image to a specific tag in the Dockerfile to ensure hermetic RPM builds succeed and avoid random dependency conflicts.

Bug Fixes:
- Prevent intermittent Konflux image build failures by aligning locked RPM versions with a fixed UBI base image

Build:
- Pin UBI base image in Dockerfile to version 9.6-1752587672