### PR TITLE
ci: image build for foreman branches

### DIFF
--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -7,7 +7,9 @@ name: Container image build and publish
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - 'main'
+      - 'foreman-*.*'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
 


### PR DESCRIPTION
RHINENG-20350

## Summary by Sourcery

CI:
- Expand container-publish workflow to run on 'foreman-*.*' branches in addition to main.