### PR TITLE
chore: fix pip setuptools error in Dockerfile.upstream

### DIFF
--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -11,6 +11,6 @@ RUN set -ex && if [ -e `which python3.11` ]; then ln -s `which python3.11` /usr/
 
 COPY Pipfile Pipfile.lock main.py ${APP_ROOT}/src/
 RUN python -m pip install --upgrade pip && \
-    python -m pip install pipenv && \
+    python -m pip install pipenv --ignore-installed && \
     pipenv install --system --ignore-pipfile
 COPY yuptoo ${APP_ROOT}/src/yuptoo/


### PR DESCRIPTION
- error: uninstall-no-record-file

adopt same fix for Dockerfile in #252

## Summary by Sourcery

Build:
- Fix pip setuptools uninstall-no-record-file error in Dockerfile.upstream by adopting same fix from the main Dockerfile (#252)