### PR TITLE
chore(ci): increase commit message length limit to 100 chars

### DIFF
--- a/.github/workflows/commit_checker.yaml
+++ b/.github/workflows/commit_checker.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Check Commit Length
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^.{10,70}(\n(\n.{0,100})*)?$'
-          error: 'The maximum line length be exceeded. Requires the first line to contain 10-70 characters and, if the message continues, the second line must be empty and the following lines 0-100 characters long.'
+          pattern: '^.{10,100}(\n(\n.{0,100})*)?$'
+          error: 'The maximum line length has been exceeded. Requires the first line to contain 10-100 characters and, if the message continues, the second line must be empty and the following lines 0-100 characters long.'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           # excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request


### PR DESCRIPTION
to accommodate automated dependency update commits from Konflux
pipelines, which include full package paths and version numbers

## Summary by Sourcery

CI:
- Increase the allowed first-line commit message length in the commit checker workflow from 70 to 100 characters and update the associated error message text.