### PR TITLE
chore(deps): bump konflux-pipelines to v1.67.0

### DIFF
--- a/.tekton/yuptoo-pull-request.yaml
+++ b/.tekton/yuptoo-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.62.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-yuptoo

--- a/.tekton/yuptoo-push.yaml
+++ b/.tekton/yuptoo-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.62.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-yuptoo


### PR DESCRIPTION
Bumps `konflux-pipelines` from v1.62.0 to v1.67.0 in the Tekton pipeline definitions.

## Files changed

- `.tekton/yuptoo-pull-request.yaml`
- `.tekton/yuptoo-push.yaml`

## Note

Mintmaker PR #390 also targets v1.67.0 on `main`. This PR is opened from the `Odilhao:bump/konflux-pipelines-v1.67.0-main` branch as requested by the release team. One of the two should be merged and the other closed.

## Summary by Sourcery

Build:
- Point pull request and push Tekton pipelines to the konflux-pipelines docker-build-oci-ta.yaml at version v1.67.0.