### PR TITLE
chore(deps): bump konflux-pipelines to v1.67.0 [foreman-3.16]

### DIFF
--- a/.tekton/iop-yuptoo-sat-6-18-pull-request.yaml
+++ b/.tekton/iop-yuptoo-sat-6-18-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "foreman-3.16"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.61.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: iop-yuptoo-sat-6-18

--- a/.tekton/iop-yuptoo-sat-6-18-push.yaml
+++ b/.tekton/iop-yuptoo-sat-6-18-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "foreman-3.16"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.61.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: iop-yuptoo-sat-6-18

--- a/.tekton/yuptoo-pull-request.yaml
+++ b/.tekton/yuptoo-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.61.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-yuptoo

--- a/.tekton/yuptoo-push.yaml
+++ b/.tekton/yuptoo-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.61.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.67.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-yuptoo


### PR DESCRIPTION
Bumps `konflux-pipelines` from v1.61.0 to v1.67.0 in the Tekton pipeline definitions for the `foreman-3.16` branch.

## Files changed

- `.tekton/iop-yuptoo-sat-6-18-pull-request.yaml`
- `.tekton/iop-yuptoo-sat-6-18-push.yaml`
- `.tekton/yuptoo-pull-request.yaml`
- `.tekton/yuptoo-push.yaml`

Main branch fix: #391

## Summary by Sourcery

Build:
- Bump konflux-pipelines reference from v1.61.0 to v1.67.0 in all relevant Tekton pipeline YAMLs.